### PR TITLE
 Forward CreateCatalogItem $warnings to Warning output stream

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
@@ -185,6 +185,13 @@ function Write-RsCatalogItem
                     try
                     {
                         $Proxy.CreateCatalogItem($itemType, $itemName, $RsFolder, $Overwrite, $bytes, $null, [ref]$warnings) | Out-Null
+                        if ($warnings)
+                        {
+                          foreach ($warn in $warnings)
+                          {
+                            Write-Warning $warn.Message
+                          }
+                        }
                     }
                     catch
                     {


### PR DESCRIPTION
Fixes issue #91

Changes proposed in this pull request:
 - Use Write-Warning to forward to user warnings reported by the report server
 - These warnings are not captured in Visual Studio when compiling, and, to the best of my knowledge, can only be data mined during deployment, making it incredibly valuable to surface to the user doing deployments

How to test this code:
 - I'm open to suggestions

Has been tested on (remove any that don't apply):
 - Powershell 5 and above
 - Windows 10 and above
 - SQL Server 2016 and above
